### PR TITLE
Add logic for dealing with hard urls in content attr

### DIFF
--- a/src/build/fetchTemplate.js
+++ b/src/build/fetchTemplate.js
@@ -59,6 +59,12 @@ module.exports = async () => {
             node.setAttribute('src', `https://www.digitalocean.com${src}`);
         }
     });
+    document.querySelectorAll('[content]').forEach(node => {
+        const content = node.getAttribute('content');
+        if (content.startsWith('/')) {
+            node.setAttribute('content', `https://www.digitalocean.com${content}`);
+        }
+    });
 
     // Inject charset
     const charset = document.createElement('meta');


### PR DESCRIPTION
## Type of Change

index template building.

## What issue does this relate to?

N/A

### What should this PR do?

Resolves an issue around the following line being introduced to the source on the Community site and breaking the parcel build process on tools:

```html
<meta name="msapplication-TileImage" content="/assets/community/ms-icon-144x144-42910a539ffa155564177508290143e5.png">
```

### What are the acceptance criteria?

When the index template is fetched, this URL is correctly prefixed with `www.digitalocean.com`.