### PR TITLE
Make the content injection more robust

### DIFF
--- a/src/build/fetchTemplate.js
+++ b/src/build/fetchTemplate.js
@@ -81,8 +81,8 @@ module.exports = async () => {
     rawHTML = rawHTML.replace('</head>', '<block name="head"></block></head>');
 
     // Inject content block
-    rawHTML = rawHTML.replace(/<div class=['"]wrapper layout-wrapper['"]>\s+?<div class=['"]clearfix['"]><\/div>\s+?<\/div>/,
-        '<div class="wrapper layout-wrapper"><block name="content"></block><div class="clearfix"></div></div>');
+    rawHTML = rawHTML.replace(/<div class=['"]wrapper layout-wrapper['"]>/,
+        '<div class="wrapper layout-wrapper"><block name="content"></block>');
 
     // Inject last fetch comment
     rawHTML = rawHTML.replace('<head>', `<!-- Last fetch from www.digitalocean.com @ ${(new Date()).toISOString()} -->\n<head>`);


### PR DESCRIPTION
## Type of Change

Template generation

## What issue does this relate to?

Blocking https://github.com/do-community/kubernetes-tool/pull/23

### What should this PR do?

Community HTML got updated, this makes the replacement for content injection less specific and more robust so ti shouldn't break again.

### What are the acceptance criteria?

It generates a valid template HTML file with the content block injected.