### PR TITLE
Disable hot reload in production

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -87,6 +87,9 @@ module.exports = (source, dest, dev) => ({
             {
                 test: /\.vue$/,
                 loader: 'vue-loader',
+                options: {
+                    hotReload: dev,
+                },
             },
             {
                 test: /\.ya?ml$/,
@@ -132,14 +135,14 @@ module.exports = (source, dest, dev) => ({
             process: 'process/browser.js',
             Buffer: ['buffer', 'Buffer'],
         }),
-        new webpack.HotModuleReplacementPlugin(),
+        dev ? new webpack.HotModuleReplacementPlugin() : null,
         new BundleAnalyzerPlugin({ analyzerMode: 'static', openAnalyzer: false }),
         new VueLoaderPlugin(),
         new MiniCssExtractPlugin({ filename: 'style.css' }),
         new HtmlWebpackPlugin({
             template: path.join(source, 'index.html'),
             inject: false,
-            minify: false,
+            minify: !dev,
         }),
-    ],
+    ].filter(x => x !== null),
 });


### PR DESCRIPTION
## Type of Change

Webpack config

## What issue does this relate to?

cc https://github.com/do-community/bandwidth-tool/pull/45

### What should this PR do?

Disabled all hot reload functionality in production, reducing generated bundles by about 25KB.

### What are the acceptance criteria?

Dev & production builds work as before -- tested in the referenced bandwidth-tool PR.