### PR TITLE
Fix webpack dynamic chunk import URLs

### DIFF
--- a/demo/src/dynamic/alert.js
+++ b/demo/src/dynamic/alert.js
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+alert('i have loaded');

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -25,6 +25,9 @@ limitations under the License.
                 Count: <span id="counter">0</span> | <a href="javascript:addOne()">Add One</a>
             </p>
             <p>
+                <a href="javascript:loadDynamicAlert()">Load dynamic alert</a>
+            </p>
+            <p>
                 <i>(this test specifically uses the window to ensure webpack is behaving properly)</i>
             </p>
         </div>

--- a/demo/src/mount.js
+++ b/demo/src/mount.js
@@ -35,3 +35,8 @@ window.addOne = () => {
 
 // Make sure other elements aren't in global scope.
 if (window.counter === 0 || window.counterElement) throw new Error('Parts of mount should not be in global scope.');
+
+// Try out dynamic stuff
+window.loadDynamicAlert = async () => {
+    await import('./dynamic/alert');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9273,39 +9273,6 @@
         }
       }
     },
-    "webpack-inject-plugin": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/webpack-inject-plugin/-/webpack-inject-plugin-1.5.5.tgz",
-      "integrity": "sha512-cYhj/3X6m19zmIEb/Y09/VjCf9SeL+/7Wv6YrUi/wBGFQPFMINEfzHBJV0qokeqvUwE23h8NzrTIrkHALZ9PaA==",
-      "requires": {
-        "loader-utils": "~1.2.3"
-      },
-      "dependencies": {
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
-        }
-      }
-    },
     "webpack-log": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9273,6 +9273,39 @@
         }
       }
     },
+    "webpack-inject-plugin": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/webpack-inject-plugin/-/webpack-inject-plugin-1.5.5.tgz",
+      "integrity": "sha512-cYhj/3X6m19zmIEb/Y09/VjCf9SeL+/7Wv6YrUi/wBGFQPFMINEfzHBJV0qokeqvUwE23h8NzrTIrkHALZ9PaA==",
+      "requires": {
+        "loader-utils": "~1.2.3"
+      },
+      "dependencies": {
+        "emojis-list": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
+    },
     "webpack-log": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
@@ -9288,6 +9321,11 @@
           "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
         }
       }
+    },
+    "webpack-require-from": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/webpack-require-from/-/webpack-require-from-1.8.3.tgz",
+      "integrity": "sha512-2Zdb0SKxLBm8RB/SjUtaNxytw5RcvHePYZhoeGexIbHt0eLOil/gpBWJEDXG+aZma3zKNUll5F0oee5xDQWbIQ=="
     },
     "webpack-sources": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "webpack": "^5.30.0",
     "webpack-bundle-analyzer": "^4.4.0",
     "webpack-dev-server": "^3.11.2",
-    "webpack-inject-plugin": "^1.5.5",
     "webpack-require-from": "^1.8.3",
     "yaml-loader": "^0.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "webpack": "^5.30.0",
     "webpack-bundle-analyzer": "^4.4.0",
     "webpack-dev-server": "^3.11.2",
+    "webpack-inject-plugin": "^1.5.5",
+    "webpack-require-from": "^1.8.3",
     "yaml-loader": "^0.6.0"
   },
   "devDependencies": {

--- a/src/webpack-dynamic-import.js
+++ b/src/webpack-dynamic-import.js
@@ -1,0 +1,22 @@
+/*
+Copyright 2021 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const originalSrcDir = document.currentScript.src.split('/').slice(0, -1).join('/');
+(typeof global === 'undefined' ? window : global).__replaceWebpackDynamicImport = path => {
+    const base = path.split('/').pop();
+    console.log(`Modifying import ${path} to use dir ${originalSrcDir} and base ${base}`);
+    return `${originalSrcDir}/${base}`;
+};

--- a/src/webpack-dynamic-import.js
+++ b/src/webpack-dynamic-import.js
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const originalSrcDir = document.currentScript.src.split('/').slice(0, -1).join('/');
-(typeof global === 'undefined' ? window : global).__replaceWebpackDynamicImport = path => {
-    const base = path.split('/').pop();
-    console.log(`Modifying import ${path} to use dir ${originalSrcDir} and base ${base}`);
-    return `${originalSrcDir}/${base}`;
+const originalSrcDir = document.currentScript.src.split('/').slice(0, -1).join('/') + '/';
+window.__webpackDynamicImportURL = () => {
+    console.info(`Using ${originalSrcDir} for webpack dynamic import`);
+    return originalSrcDir;
 };

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -133,7 +133,7 @@ module.exports = (source, dest, dev) => ({
         extensions: ['.js', '.jsx', '.json', '.ts', '.tsx', '.css', '.scss', '.sass', '.html', '.vue', '.yml', '.yaml'],
     },
     plugins: [
-        // Fix dynamic imports from CDN
+        // Fix dynamic imports from CDN (inject as first entry point before any imports can happen)
         { apply: compiler => {
             compiler.options.entry.mount.import.unshift(path.join(__dirname, 'webpack-dynamic-import.js'));
         } },

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -28,12 +28,12 @@ module.exports = (source, dest, dev) => ({
     devtool: 'source-map',
     mode: dev ? 'development' : 'production',
     entry: {
-        'mount.js': path.join(source, 'mount.js'),
+        mount: path.join(source, 'mount.js'),
     },
     output: {
         path: dest,
         publicPath: './',
-        filename: '[name]',
+        filename: '[name].js',
     },
     optimization: {
         minimize: true,
@@ -155,7 +155,7 @@ module.exports = (source, dest, dev) => ({
         // Fix dynamic imports from CDN
         new WebpackRequireFrom({ replaceSrcMethodName: '__replaceWebpackDynamicImport' }),
         { apply: compiler => {
-            compiler.options.entry['mount.js'].import.unshift(path.join(__dirname, 'webpack-dynamic-import.js'));
+            compiler.options.entry.mount.import.unshift(path.join(__dirname, 'webpack-dynamic-import.js'));
         } },
     ].filter(x => x !== null),
 });

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -17,14 +17,12 @@ limitations under the License.
 const webpack = require('webpack');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const process = require('process');
-const fs = require('fs');
 const path = require('path');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const WebpackRequireFrom = require('webpack-require-from');
-const { default: InjectPlugin, ENTRY_ORDER } = require('webpack-inject-plugin');
 
 module.exports = (source, dest, dev) => ({
     devtool: 'source-map',
@@ -156,8 +154,8 @@ module.exports = (source, dest, dev) => ({
         }),
         // Fix dynamic imports from CDN
         new WebpackRequireFrom({ replaceSrcMethodName: '__replaceWebpackDynamicImport' }),
-        new InjectPlugin(() => {
-            return fs.readFileSync(path.join(__dirname, 'webpack-dynamic-import.js'), 'utf8');
-        }, { entryName: 'mount.js', entryOrder: ENTRY_ORDER.First }),
+        { apply: compiler => {
+            compiler.options.entry['mount.js'].import.unshift(path.join(__dirname, 'webpack-dynamic-import.js'));
+        } },
     ].filter(x => x !== null),
 });

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -133,6 +133,11 @@ module.exports = (source, dest, dev) => ({
         extensions: ['.js', '.jsx', '.json', '.ts', '.tsx', '.css', '.scss', '.sass', '.html', '.vue', '.yml', '.yaml'],
     },
     plugins: [
+        // Fix dynamic imports from CDN
+        { apply: compiler => {
+            compiler.options.entry.mount.import.unshift(path.join(__dirname, 'webpack-dynamic-import.js'));
+        } },
+        new WebpackRequireFrom({ methodName: '__webpackDynamicImportURL' }),
         // Polyfill process & buffer
         new webpack.ProvidePlugin({
             process: 'process/browser.js',
@@ -152,10 +157,5 @@ module.exports = (source, dest, dev) => ({
             inject: false,
             minify: !dev,
         }),
-        // Fix dynamic imports from CDN
-        new WebpackRequireFrom({ replaceSrcMethodName: '__replaceWebpackDynamicImport' }),
-        { apply: compiler => {
-            compiler.options.entry.mount.import.unshift(path.join(__dirname, 'webpack-dynamic-import.js'));
-        } },
     ].filter(x => x !== null),
 });


### PR DESCRIPTION
## Type of Change

Webpack bundling

## What issue does this relate to?

N/A

### What should this PR do?

Enables the webpack-require-from plugin for do-vue to ensure that any dynamic imports (`await import(...)`) are imported from the base URL of the original script and not the current page that the tool is embedded in.

This also changes our output name format to includes `.js` so that our chunks are emitted as JavaScript files.

### What are the acceptance criteria?

Clicking the `Load dynamic alert` link in the demo should trigger the chunk to be loaded before an alert is shown on the screen from that chunk. In console, an informational message should be logged that contains the base URL used for the chunk import.