### PR TITLE
Inject full environment into webpack

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -143,6 +143,8 @@ module.exports = (source, dest, dev) => ({
             process: 'process/browser.js',
             Buffer: ['buffer', 'Buffer'],
         }),
+        // Inject full environment
+        new webpack.EnvironmentPlugin(Object.keys(process.env)),
         // Enable HMR for dev
         dev ? new webpack.HotModuleReplacementPlugin() : null,
         // Analyze the bundle


### PR DESCRIPTION
## Type of Change

Webpack config

## What issue does this relate to?

N/A

### What should this PR do?

Makes the full Node environment available in JS being bundled by Webpack.

### What are the acceptance criteria?

`process.env.<x>` is defined in scripts bundled by Webpack when using this branch.