### PR TITLE
Enable suppressErrors in WebpackRequireFrom

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -144,7 +144,7 @@ module.exports = (source, dest, dev) => ({
         { apply: compiler => {
             compiler.options.entry.mount.import.unshift(path.join(__dirname, 'webpack-dynamic-import.js'));
         } },
-        new WebpackRequireFrom({ methodName: '__webpackDynamicImportURL' }),
+        new WebpackRequireFrom({ methodName: '__webpackDynamicImportURL', suppressErrors: true }),
         // Polyfill process & buffer
         new webpack.ProvidePlugin({
             process: 'process/browser.js',


### PR DESCRIPTION
## Type of Change

Webpack config

## What issue does this relate to?

N/A

### What should this PR do?

Suppresses the errors emitted from the WebpackRequireFrom plugin, as we inject the required global method as part of the Webpack config itself.

### What are the acceptance criteria?

No errors emitted by plugin, build works as expected.