### PR TITLE
Fix missing space in ExternalLink

### DIFF
--- a/src/templates/external_link.vue
+++ b/src/templates/external_link.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ limitations under the License.
 <template>
     <span>
         <a :href="link" target="_blank" rel="noreferrer" v-text="text"></a>
+        {{ " " }}
         <i class="fas fa-external-link-alt"></i>
     </span>
 </template>


### PR DESCRIPTION
## Type of Change

ExternalLink component

## What issue does this relate to?

N/A

### What should this PR do?

With the update to Vue 3 a while back, it looks like implicit spaces changed and there was no longer a space between the link text and the icon in ExternalLink, so this PR adds an explicit space in.

### What are the acceptance criteria?

ExternalLink now has a space between the text and icon.